### PR TITLE
Add JSON output option to info command

### DIFF
--- a/app/Console/Commands/InfoCommand.php
+++ b/app/Console/Commands/InfoCommand.php
@@ -10,7 +10,7 @@ class InfoCommand extends Command
 {
     protected $description = 'Displays the application, database, and email configurations along with the panel version.';
 
-    protected $signature = 'p:info';
+    protected $signature = 'p:info {--format=text : The output format: "text" or "json". }';
 
     /**
      * VersionCommand constructor.
@@ -25,6 +25,52 @@ class InfoCommand extends Command
      */
     public function handle()
     {
+        $format = $this->option('format');
+
+        $data = [
+            'version' => [
+                'Panel Version' => $this->config->get('app.version'),
+                'Latest Version' => $this->versionService->getPanel(),
+                'Up-to-Date' => $this->versionService->isLatestPanel() ? 'Yes' : 'No',
+                'Unique Identifier' => $this->config->get('pterodactyl.service.author'),
+            ],
+            'application' => [
+                'Environment' => $this->config->get('app.env'),
+                'Debug Mode' => $this->config->get('app.debug') ? 'Yes' : 'No',
+                'Installation URL' => $this->config->get('app.url'),
+                'Installation Directory' => base_path(),
+                'Timezone' => $this->config->get('app.timezone'),
+                'Cache Driver' => $this->config->get('cache.default'),
+                'Queue Driver' => $this->config->get('queue.default'),
+                'Session Driver' => $this->config->get('session.driver'),
+                'Filesystem Driver' => $this->config->get('filesystems.default'),
+                'Default Theme' => $this->config->get('themes.active'),
+                'Proxies' => $this->config->get('trustedproxies.proxies'),
+            ],
+            'database' => [
+                'Driver' => $this->config->get('database.default'),
+                'Host' => $this->config->get("database.connections." . $this->config->get('database.default') . '.host'),
+                'Port' => $this->config->get("database.connections." . $this->config->get('database.default') . '.port'),
+                'Database' => $this->config->get("database.connections." . $this->config->get('database.default') . '.database'),
+                'Username' => $this->config->get("database.connections." . $this->config->get('database.default') . '.username'),
+            ],
+            'email' => [
+                'Driver' => $this->config->get('mail.default'),
+                'Host' => $this->config->get('mail.mailers.smtp.host'),
+                'Port' => $this->config->get('mail.mailers.smtp.port'),
+                'Username' => $this->config->get('mail.mailers.smtp.username'),
+                'From Address' => $this->config->get('mail.from.address'),
+                'From Name' => $this->config->get('mail.from.name'),
+                'Encryption' => $this->config->get('mail.mailers.smtp.encryption'),
+            ],
+        ];
+
+        if ($format === 'json') {
+            $this->output->write(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            $this->output->newLine();
+
+            return 0;
+        }
         $this->output->title('Version Information');
         $this->table([], [
             ['Panel Version', $this->config->get('app.version')],


### PR DESCRIPTION
## Summary
- extend `p:info` command with a `--format` option
- support JSON output for easier automation

## Testing
- `yarn test` *(fails: package not present in lockfile)*